### PR TITLE
Bugfix i numberString

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,7 +77,7 @@ export const numberString = (n: number, neutral = false): string => {
 
     // n < 20
     const low = lowNumbers(neutral, isEmpty(str))[n]
-    if (low) return str + (isEmpty(str) || !and ? low : `${str} og ${low}`)
+    if (low) return str + (isEmpty(str) || !and ? low : ` og ${low}`)
   } while (n > 0)
 
   return str


### PR DESCRIPTION
numberString har en liten bug der den dobler opp det som kommer før et tall fra "en" til "nitten" (står eksempelvis "hundrehundre og to snille barn" på ledertavla nå, virker også som 1101 blir "elleve hundreelleve hundre og en".

Definitivt laveste prioritet som finnes, er bare litt irriterende å se på de gangene det inntreffer.