### PR TITLE
Fix [object Object] in door 24

### DIFF
--- a/src/components/Door/Input.tsx
+++ b/src/components/Door/Input.tsx
@@ -54,7 +54,7 @@ const Input: FC<InputProps> = ({ door }) => {
     return (
       <CheckMark
         wrapperClassName="w-16 md:w-28 mx-auto"
-        message={`Bra jobba!${door === 24 ? <><br />Og god jul! 🥳</> : ""}`}
+        message={`Bra jobba!${door === 24 ? "Og god jul! 🥳": ""}`}
         scrollTo={attemptCount > 0}
       />
     )


### PR DESCRIPTION
Nå står det "Bra jobba![object Object]" under checkmarken på siste luke. Dette kommer, så vidt jeg kan se, av at componenten blir lagt direkte inn i en string.

En liten endring som kom med i denne løsningen er at det ikke er noe linjeskift lenger. Jeg tror ikke det går an å få linjeskift uten å bruke en component, som bryter med typingen til message (som skal være string). Dermed ble dette den enkleste løsningen jeg fant.

Ellers får jeg ta denne muligheten til å takke for en morsom julekalender, og ønske dere en god jul!